### PR TITLE
使用新的发布解决tag问题

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -124,12 +124,19 @@ jobs:
           rar a danmuji.rar danmuji/
           tar cvf danmuji.tar danmuji/
 
+      # - name: Upload Files To Release
+      #   uses: ncipollo/release-action@main
+      #   with:
+      #     tag: ${{ steps.prepare.outputs.TAG }}
+      #     allowUpdates: true
+      #     replacesArtifacts: true
+      #     body: ${{ env.BUILD_DATE }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     artifacts: danmuji.tar,danmuji-green.rar,danmuji-green.zip,danmuji.rar,danmuji.zip
       - name: Upload Files To Release
-        uses: ncipollo/release-action@main
+        uses: softprops/action-gh-release@v1
         with:
-          tag: ${{ steps.prepare.outputs.TAG }}
-          allowUpdates: true
-          replacesArtifacts: true
-          body: ${{ env.BUILD_DATE }}
+          name: ${{ steps.prepare.outputs.TAG }}
+          tag_name: ${{ steps.prepare.outputs.tag_version }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: danmuji.tar,danmuji-green.rar,danmuji-green.zip,danmuji.rar,danmuji.zip
+          files: danmuji.tar,danmuji-green.rar,danmuji-green.zip,danmuji.rar,danmuji.zip


### PR DESCRIPTION
在 #48 中发布版本会造成 `releases/tag/弹幕姬发行版#{版本号}(含绿色版本)`的地址存在，使用新的发布 `releases/tag/#{版本号}`