### PR TITLE
简化弹幕机初始化服务逻辑,去除冗余逻辑.捕获一些遗漏异常.

### DIFF
--- a/src/main/java/xyz/acproject/danmuji/conf/CenterSetConf.java
+++ b/src/main/java/xyz/acproject/danmuji/conf/CenterSetConf.java
@@ -1,13 +1,19 @@
 package xyz.acproject.danmuji.conf;
 
 
+import com.alibaba.fastjson.JSONException;
+import com.alibaba.fastjson.JSONObject;
 import com.alibaba.fastjson.annotation.JSONField;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.Assert;
 import xyz.acproject.danmuji.conf.set.*;
+import xyz.acproject.danmuji.tools.BASE64Encoder;
 import xyz.acproject.danmuji.utils.FastJsonUtils;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 /**
@@ -20,6 +26,7 @@ import java.io.Serializable;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Slf4j
 public class CenterSetConf implements Serializable {
     /**
      *
@@ -152,6 +159,27 @@ public class CenterSetConf implements Serializable {
 
     public String toJson() {
         return FastJsonUtils.toJson(this);
-       // return FastJsonUtils.toJson(new CenterSetConf(is_barrage_guard, is_barrage_vip, is_barrage_manager, is_barrage_medal, is_barrage_ul,is_barrage_anchor_shield, is_block, is_gift, is_welcome, is_welcome_all, is_follow, is_log, is_cmd, roomid, is_auto,win_auto_openSet,is_manager_login,manager_key,manager_maxSize, is_online, is_sh, is_dosign,sign_time ,thank_gift, advert, follow, reply, clock_in, welcome,auto_gift,privacy));
+    }
+
+    /**
+     * Let a base64 content to a CenterSetConf object.
+     * @param base64 将json字符串base64编码的内容
+     * @return is not null
+     */
+    public static CenterSetConf of(String base64){
+        Assert.notNull(base64, "Base64 must cannot be null");
+        BASE64Encoder base64Encoder = new BASE64Encoder();
+        try {
+            //fastjson没有完善的javadoc, 方法抛出的异常也未明确指出. 是否考虑更换较规范的库?
+            // {@link JSONObject#parseObject} 方法调用的异常捕获并未完全覆盖
+            return JSONObject.parseObject(new String(base64Encoder.decode(base64)), CenterSetConf.class);
+        } catch (IOException|JSONException e) {
+            // 因用户非法操作导致的,记录等级为warn;开发者使用方法不当导致的,记录等级为error.(不那么准确,但是warn级别确定是用户非法操作导致)
+            // 在数据模型中的方法面向开发者,故给予error级别记录. 其实此处的异常也会因为用户非法修改profile文件内容导致异常.
+            // 解析失败
+            log.error(e.getMessage(), e);
+            // 在异常时提供默认对象, 避免反复处理解析失败异常
+            return new CenterSetConf();
+        }
     }
 }

--- a/src/main/java/xyz/acproject/danmuji/service/impl/SetServiceImpl.java
+++ b/src/main/java/xyz/acproject/danmuji/service/impl/SetServiceImpl.java
@@ -31,15 +31,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * @date 2020年8月10日 下午12:17:03
  * @Copyright:2020 blogs.acproject.xyz Inc. All rights reserved.
  */
-@SuppressWarnings("all")
 @Service
 public class SetServiceImpl implements SetService {
-    private Logger LOGGER = LogManager.getLogger(SetServiceImpl.class);
+    private final Logger LOGGER = LogManager.getLogger(SetServiceImpl.class);
     private final String cookies = "ySZL4SBB";
     private ClientService clientService;
     private ThreadComponent threadComponent;
-
-    private SetService setService;
     private ServerAddressComponent serverAddressComponent;
     private TaskRegisterComponent taskRegisterComponent;
 
@@ -364,10 +361,5 @@ public class SetServiceImpl implements SetService {
     @Autowired
     public void setTaskRegisterComponent(TaskRegisterComponent taskRegisterComponent) {
         this.taskRegisterComponent = taskRegisterComponent;
-    }
-
-    @Autowired
-    public void setSetService(SetService setService) {
-        this.setService = setService;
     }
 }

--- a/src/main/java/xyz/acproject/danmuji/tools/RequestHeaderTools.java
+++ b/src/main/java/xyz/acproject/danmuji/tools/RequestHeaderTools.java
@@ -1,0 +1,27 @@
+package xyz.acproject.danmuji.tools;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Tatooi
+ * @since 2.6.41
+ */
+public class RequestHeaderTools {
+    private RequestHeaderTools() {
+    }
+
+    public static Map<String,String> parseCookies(String cookieCluster){
+        HashMap<String, String> cookieKeyValueMap = new HashMap<>();
+        String cookiesString = cookieCluster.trim();
+        String[] cookies = cookiesString.split(";");
+        for (String cookieString : cookies) {
+            if (cookieString.contains("=")) {
+                String[] maps = cookieString.split("=");
+                cookieKeyValueMap.put(maps[0],maps.length >= 2 ? maps[1] : "");
+            }
+        }
+
+        return cookieKeyValueMap;
+    }
+}

--- a/src/test/java/xyz/acproject/danmuji/conf/CenterSetConfTest.java
+++ b/src/test/java/xyz/acproject/danmuji/conf/CenterSetConfTest.java
@@ -1,0 +1,30 @@
+package xyz.acproject.danmuji.conf;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import xyz.acproject.danmuji.conf.set.ThankFollowSetConf;
+
+/**
+ * @author Tatooi
+ * @since 2.6.41
+ */
+class CenterSetConfTest {
+
+    @Test
+    void normalCaseForOf() {
+        CenterSetConf cen = CenterSetConf.of("8O@2zazB6D{3[DI3y<]Sz~@q6O!w!3!I!CBP~SNF7C>95tgB53!wzCcI6S?I!CBP~SZmz<U3[Cz25a)B$f@P7bcq7~^3[0hI!D]F5<?3[0hK^aqI!CcR7bZ9zSBC7f!w8O@F6RZL6b>K!0FCy<NPz`m36CZL5>ZFzf!w!3!I!D]F5<?3[3!O^PEq)|Em^f@Z$f@27~]L~t)27C>96S>q!0FCy<NPz`m3yCN2ySI3[DI3y<NI!0FCy<NPz`m3y~>q5RZOz~gI8`!wzCcI6S?I!CzR8DFV~tcRz~@V!0FCy<NPz`m35Ccez~^3[Be7$f@q4bcK4RZC5SNI5t63[Cz25a)B$f@q4bcK4RZD4<zq!0FCy<NPz`m37b225Ce97S>IySZez`!wzCcI6S?I!D>Fza^3[Be79`m3ySNLySe94<U3[DI3yCcO6CcDz`!w!K8eLK<!If!I!CBP~SZmz<U3[Cz25a)B$f@q4<RB!0E3^.hw^P?w^.h39`m3zCZI5bZt!0FX!C]B5bcV7bBez`!w^OUm$f@C5SNI5t7?4bcK4O!wzCcI6S?I!CzL5bNL7t^3[3$EI#$EI#!B7?V25<>P@8842[<cI+4PGaU3$f@F6RZI4~zB~SZmz<U3[Cz25a)B$f@F6RZL6b>K!0FCy<NPz`m34~)97a296S2Fz<NA!0FCy<NPz`m35D>e!0EN9`m34~)9y~>q5O!wzCcI6S?I!CBP~S@26D@2zS?3[D]O7<?I!CBP~S@26D@2zS>9y<V04bZO~t)E4<>Izf!wzCcI6S?I!CBP~S@26D@2zS>9zt>26C{3[D]O7<?I!CBP~S@26D@2zS>95<cKy<7B63!w7a@Rz`m34~)9yCcO6CcDz>Zez<]25f!wzCcI6S?I!CBP~S@26D@2zS>97<m3[Cz25a)B$f@F6RZ3y~@Oy<7B~tzF6f!w7a@Rz`m34~)9yCNLySI3[D]O7<?I!CBP~S)ezf!w7a@Rz`m34~)9zbZP4<7K!0FCy<NPz`m34~)9zCZI5bZt~S]e!0Fq6D>B$f@F6RZD4<zq!0Fq6D>B$f@F6RZD4<zq~SzOz<?3[D]O7<?I!CBP~SR25CcDz~@95bZD4<U3[Cz25a)B$f@F6RZL5CNF5C?3[Cz25a)B$f@F6RZP4f!wzCcI6S?I!CBP~t7B5b)L5<>9y<NI!0FCy<NPz`m34~)97S>IySZez>ZVz`!w7a@Rz`m35bZD!0FCy<NPz`m35<cKy<7B6BZHz~A3[3!O^.@0y0AS^Cc0)|Am)P>3[|yqy0ht^|?Oz.!P)b!t^f!I!CR25CcDz~@95<cU?SBwz`!w^|hI!DgO4~z2ytA3[DI3ySNLySe@5A]28`!w^fm34~)95tgB53!wzCcI6S?I!D)FzSVdy~A3[0hI!D)ey<NI~S2By~@q~t>O5f!w!C2q7ahw$OZ34<NF4b>26D{e^`VEz~@L4t>26ahKySZe$S>KyO@Z$f@Oz~gI8`!w8O@27~]L?C>m5aB|z~]P!0F58O@F6RZ2yS)R6Ccqz`!wzCcI6S?I!CBP~SZmz<U3[D]O7<?I!CeB8~7L6C]P!0F5!K<6G[<VIK`X1[`V3aNYVzOEV5COVz359aPBD#0B1zHAKU.AKy2Y9[<gCK`X1[`V3[<6Gf@7$f@Oz~gI8`!w!K4)E+CYA+81e[8HC8<YK8<VB8<6G.V9}f!I!D)E4<>Iza^3[Be79>qI!CBP~SNF7C>95tgB53!w7a@Rz`m34~)95tgB53!w7a@Rz`m35bBP7cZmz<Zm5b>96S2Fz<NA~t)qy~]R6O!w^fm37bBez`!w^fUm9`m36CZL5<BA!0Et).1R).?m$f@P4<7K~t]F5<?3[3!m^.EP^.Em^f!I!D]Ey<VH~S7FzD{3[DI3ySZAz>)q6CBKzt^3[Be7$f@Az<N28~]F5<?3[0^K^fm3zSBC7c)q6CBKzt^3[Be7$f@D4<zq>b225CI3[Cz25a)B$f@F6RZD4<zq~S)Lzb?3[Cz25a)B$f@F6RZD7<cOzcZI5S)25f!wzCcI6S?I!CBP~S7Ry~@A~t@B6bZO7f!wzCcI6S?I!CBP~SNF7C>95tgB53!wzCcI6S?I!CBP~SZmz<U3[Cz25a)B$f@F6RZq8cZP4bBB5b{3[Cz25a)B$f@I4~)q~S7FzD]96S2Fz<NA~t)qy~]R6O!w^fm35bBP7cZmz<Zm5b>96S2Fz<NA~t)qy~]R6O!w^fm35D>e!0EN$f@Oz~gL6D{3[3!3$f@Oz~gL6D]9yCcO6CcDz`!w!3!I!D)E4<>IzcZP7bcq7~^3[0hI!D]Ey<VH!0E3VE`9w$f3@~>[y<RB@8<AF+`ZHf>?8~gB@8842f>a4<zq|Ccez`?18f>[7<qB93!I!D]Ey<VH]SBC7c@R5b>|z~]P!0F5~`m37b225Ce96t]27a>P!0Em9`m37S>IySZez`!w8O@Az<N28~]F5<?3[0^K^fm34~)95bBSz>ZL6b>K!0Fq6D>B$f@F6RZL6b>K!0Fq6D>B$f@F6RZq8cZP4bBB5b{3[Cz25a)B$f@I4~)q~tgB5tgIz>ZP4bBB5b]96t]27a>P!0Em$f@K7<q3[0dI!D7B5b)L5<>?4bcK4O!wzCcI6S?I!D7B5b)L5<>P!0E3VGO3w$+[@~>[y<RB6O~ELVLB24~DCX|CAGtFBX]+!DqI!D7F5BZ27~]L~SZmz<V|z~{3[D]O7<>Z");
+        Assertions.assertThat(cen)
+                .extracting(CenterSetConf::is_auto, CenterSetConf::is_block, CenterSetConf::getFollow)
+                .containsExactly(false, true, new ThankFollowSetConf());
+    }
+
+    @Test
+    void emptyParamCaseForOf() {
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> CenterSetConf.of(null));
+        CenterSetConf cen1 = CenterSetConf.of("");
+        org.junit.jupiter.api.Assertions.assertNull(cen1);
+        CenterSetConf cen2 = CenterSetConf.of("{}");
+        org.junit.jupiter.api.Assertions.assertNotNull(cen2);
+
+    }
+}

--- a/src/test/java/xyz/acproject/danmuji/tools/file/ProFileToolsTest.java
+++ b/src/test/java/xyz/acproject/danmuji/tools/file/ProFileToolsTest.java
@@ -1,0 +1,43 @@
+package xyz.acproject.danmuji.tools.file;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Tatooi
+ * @since 2.6.41
+ */
+class ProFileToolsTest {
+
+
+    @BeforeAll
+    static void write() {
+        HashMap<String, String> profileMap = new HashMap<>();
+        profileMap.put("text","mono");
+        profileMap.put("title","city");
+        ProFileTools.write(profileMap,"test.file");
+    }
+
+    @Test
+    void read() {
+        Map<String, String> map;
+        try {
+            map = ProFileTools.read("test.file");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        Assertions.assertThat(map)
+                .containsEntry("text","mono")
+                .containsEntry("title","city")
+                ;
+    }
+
+
+}


### PR DESCRIPTION
# 主要修改
`DanmujiInitService` : 简化逻辑, 封装了部分非业务流程. 

# 增加两个工具类的改动
`RequestHeaderTools` : 封装cookie的解析逻辑
`ProFileTools` : 对profile文件解析,写入的逻辑简化

# 增加两个单元测试
`CenterSetConfTest` :  将base64内容转为CenterSet对象的测试
`ProFileToolsTest` :  读取profile文件的测试

