### PR TITLE
增加docker镜像部署配置

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# 忽略git相关文件
+.git
+.gitignore
+.gitattributes
+.github
+# 忽略idea下所有文件
+.idea/
+# 忽略out下生成文件
+out/
+classes/
+# 忽略target下生成文件
+target/
+# 忽略build下生成文件
+build/
+# 忽略项目.iml
+*.iml
+# 忽略项目prof文件
+*.hprof
+# 忽略word生成的临时文件
+~*
+# 忽略lib下生成文件
+.gradle/
+bin/
+*.log
+log/
+rebel.xml
+rebel-remote.xml

--- a/deploy/docker/.env
+++ b/deploy/docker/.env
@@ -1,0 +1,2 @@
+# 初始化持久文件名见 xyz.acproject.danmuji.conf.PublicDataConf.PROFILE_NAME
+PROFILE_NAME=DanmujiProfile

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM gradle:6.8-jdk8 AS buildingImage
+
+ADD . /home/gradle/project
+#USER gradle
+WORKDIR /home/gradle/project
+
+RUN set -x; gradle build
+RUN ls build/libs/*.jar | grep -v plain.jar | head -n 1 | xargs -I {} mv {} /home/app.jar
+
+FROM eclipse-temurin:8-jre
+ENV TZ Asia/Shanghai
+
+COPY --from=buildingImage /home/app.jar /workspace/app.jar
+COPY --from=buildingImage /home/gradle/project/deploy/docker/entrypoint.sh /workspace/entrypoint.sh
+WORKDIR /workspace
+ENTRYPOINT bash entrypoint.sh

--- a/deploy/docker/docker-compose.yaml
+++ b/deploy/docker/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: "3"
+
+services:
+  danmuji:
+    image: danmuji:tmp4test
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile
+    env_file: .env
+    ports:
+      - "23333:23333"
+    networks:
+      - danmuji-network
+    volumes:
+      - "profileStore:/opt/store" # 持久化配置
+
+networks:
+  danmuji-network:
+    driver: bridge
+
+volumes:
+  profileStore:

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# 如果有指定/opt/store的持久卷则提前装配它,以便运行时可被采用
+if [ -e /opt/store ]; then
+  ln -s /opt/store/profile /workspace/${PROFILE_NAME}
+fi
+JAVA_OPS=${JAVA_OPS:-"-Xms256m -Xmx1024m"}
+java $JAVA_OPS -jar app.jar


### PR DESCRIPTION
为了便于开发者持久地测试新增的功能,特地提供部署docker的配置文件~~~

可在命令行中在根目录的`deploy/docker` 工作目录下执行`docker-compose up -d --build`即可快速构建带有测试性功能的镜像并运行它.