### PR TITLE
添加新的发布脚本

### DIFF
--- a/.github/workflows/delete_old_workflow.yaml
+++ b/.github/workflows/delete_old_workflow.yaml
@@ -1,0 +1,19 @@
+name: Delete Workflow Runs
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: "0 16 * * *"
+
+jobs:
+  del_runs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete workflow runs
+        uses: Mattraks/delete-workflow-runs@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          retain_days: 1
+          keep_minimum_runs: 3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
           echo "TAG=弹幕姬发行版${TAG_VERSION}(含绿色版本)" >> $GITHUB_OUTPUT
 
           echo ${FILE_NAME}
-          echo ${TAG}
+          echo ${TAG_VERSION}
 
       # 初始化 JDK8 环境
       - name: Set up JDK 8

--- a/.github/workflows/release_update_readme.yaml
+++ b/.github/workflows/release_update_readme.yaml
@@ -1,0 +1,171 @@
+# 利用GitHub Action自动构建多框架的docker镜像
+name: release_update_readme
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseTag:
+        description: 'Release Tag' 
+        required: true
+        default: 'v'
+  # main分支的push操作会触发当前脚本的执行
+#  push:
+#    branches: [ master ]
+  # main分支的pr操作会触发当前脚本的执行
+#  pull_request:
+#    branches: [ main ]
+  # 定时任务,分时日月年,为国际标准时间16点,对应中国时间0点
+  # schedule:
+  #   - cron: '0 16 * * *'
+  # # 点击star时开始任务
+  # watch:
+  #   types: started
+
+
+jobs:
+  release_update_readme:
+    # 运行在Ubuntu系统上
+    runs-on: ubuntu-latest
+    # 步骤
+    steps:
+      # 切换到主分支
+      - name: Checkout
+        uses: actions/checkout@master
+      
+      # 获取一些参数
+      - name: Prepare
+        id: prepare
+        run: |
+          GITHUB_VERSION=$(curl -sX GET "https://api.github.com/repos/BanqiJane/Bilibili_Danmuji/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]')
+          echo "github_version=${GITHUB_VERSION}" >> $GITHUB_OUTPUT
+          
+          sed -n 7p build.gradle > version
+          awk '{printf("%s",$0)}' version | sed 's/\ //g' $1 > new
+          sed -i "s/'//g" new
+          sed -i "s/version=//g" new
+          mv new version
+          FILE_NAME=$(cat version)
+          sed -i "s/beta//g" version
+          TAG_VERSION=$(cat version)
+          echo "file_name=${FILE_NAME}" >> $GITHUB_OUTPUT
+          echo "tag_version=${TAG_VERSION}" >> $GITHUB_OUTPUT
+
+          echo "TAG=弹幕姬发行版${TAG_VERSION}(含绿色版本)" >> $GITHUB_OUTPUT
+
+          echo ${GITHUB_VERSION}
+          echo ${FILE_NAME}
+          echo ${TAG_VERSION}
+
+      # 初始化 JDK8 环境
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      # 使用Gradle编译构建
+      - name: Build with Gradle
+        run: |
+          sudo chmod +x ./gradlew
+          sudo chmod +x lib/javastruct-0.1.jar
+          sudo ./gradlew build -x test
+          sudo mv $(find build -type f -size +10M) ./
+
+      # 下载openjdk-8-jre 的压缩包，网上没有下载Windows jre8的地方，所以使用danmuji docker构建的release下载
+      - name: Download OpenJDK8 Archive
+        run: |
+          sudo apt-get install -y rar zip unzip
+          wget https://github.com/zzcabc/Docker_Buildx_Danmuji/releases/download/openjdk-8-jre/openjdk-8-jre.zip
+          unzip openjdk-8-jre.zip -d openjdk-8-jre
+
+      # 编辑文件
+      - name: Edit files
+        run: |
+          mkdir danmuji
+          mkdir danmuji-green
+
+          mv openjdk-8-jre danmuji-green/openjdk-8-jre
+
+          echo "仅在本机有jdk8或jre8版本以上的环境下" > danmuji/readme.txt
+          echo "window下：直接run.bat运行" >> danmuji/readme.txt
+          echo "其它系统或方法：在本软件目录下cmd命令行执行 java -jar -Xms64m -Xmx128m  BiliBili_Danmuji-${{ steps.prepare.outputs.file_name }}.jar --server.port=23333 即可运行" >> danmuji/readme.txt
+          echo "--server.port=23333为端口 想修改端口可以修改run.bat里面的这个参数" >> danmuji/readme.txt
+          echo "如何设置？打开浏览器地址栏输入http://127.0.0.1:23333进行设置；" >> danmuji/readme.txt
+          echo "如何退出？直接关闭命令行窗口即可退出" >> danmuji/readme.txt
+          echo "如何获取更新？建议持续关注github项目官页" >> danmuji/readme.txt
+          echo "不会使用？有问题反馈？ GitHub上开个issue提问 或者 主页 点击联系我 邮件发送" >> danmuji/readme.txt
+
+          echo "@echo off" > danmuji/run.bat
+          echo "title BiliBili_Danmuji-${{ steps.prepare.outputs.file_name }}-%date%-%time%-%cd%" >> danmuji/run.bat
+          echo "java -jar -Xms64m -Xmx128m BiliBili_Danmuji-${{ steps.prepare.outputs.file_name }}.jar --server.port=23333" >> danmuji/run.bat
+
+
+          echo "该版本为window绿色版本，" > danmuji-green/readme.txt
+          echo "运行方法：" >> danmuji-green/readme.txt
+          echo "直接运行run.bat（window下）记得允许网络" >> danmuji-green/readme.txt
+          echo "其他系统或方法：解压完成 直接在本目录打开控制台 或者 控制台cd本目录命令执行openjdk-8-jre\bin\java -jar -Xms64m -Xmx128m BiliBili_Danmuji-${{ steps.prepare.outputs.file_name }}.jar --server.port=23333 即可运行" >> danmuji-green/readme.txt
+          echo "--server.port=23333为端口 想修改端口可以修改run.bat里面的这个参数" >> danmuji-green/readme.txt
+          echo "如何设置？打开浏览器地址栏输入 http://127.0.0.1:23333进行设置；" >> danmuji-green/readme.txt
+          echo "如何退出？直接关闭命令行窗口即可退出" >> danmuji-green/readme.txt
+          echo "如何获取更新？建议持续关注github项目官页" >> danmuji-green/readme.txt
+          echo "不会使用？有问题反馈？ GitHub上开个issue提问 或者 主页 点击联系我 邮件发送" >> danmuji-green/readme.txt
+
+          echo "@echo off" > danmuji-green/run.bat
+          echo "title BiliBili_Danmuji-${{ steps.prepare.outputs.file_name }}-%date%-%time%-%cd%" >> danmuji-green/run.bat
+          echo "openjdk-8-jre\bin\java -jar -Xms64m -Xmx128m BiliBili_Danmuji-${{ steps.prepare.outputs.file_name }}.jar --server.port=23333" >> danmuji-green/run.bat
+      
+    
+      # 压缩文件
+      - name: Compressed Files
+        run: |
+          export BUILD_DATE=$(date +"%Y-%m-%d")
+          echo "BUILD_DATE=$BUILD_DATE" >> $GITHUB_ENV
+          cp ./*.jar danmuji/
+          cp ./*.jar danmuji-green/
+          zip -r danmuji-green.zip danmuji-green/
+          zip -r danmuji.zip danmuji/
+          rar a -r danmuji-green.rar danmuji-green/
+          rar a danmuji.rar danmuji/
+          tar cvf danmuji.tar danmuji/
+
+      # - name: Upload Files To Release
+      #   uses: ncipollo/release-action@main
+      #   with:
+      #     tag: ${{ steps.prepare.outputs.TAG }}
+      #     allowUpdates: true
+      #     replacesArtifacts: true
+      #     body: ${{ env.BUILD_DATE }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     artifacts: danmuji.tar,danmuji-green.rar,danmuji-green.zip,danmuji.rar,danmuji.zip
+      - name: Upload Files To Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.prepare.outputs.TAG }}
+          tag_name: ${{ steps.prepare.outputs.tag_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: danmuji.tar,danmuji-green.rar,danmuji-green.zip,danmuji.rar,danmuji.zip
+
+      # 初始化版本号与git 
+      - name: commit
+        run: |
+          git config --global user.name 
+          git config --global user.email 
+
+
+          echo "更新MD文档 版本${{ steps.prepare.outputs.github_version }} 替换成 版本${{ steps.prepare.outputs.tag_version }}"
+          sed -i "s/版本${{ steps.prepare.outputs.github_version }}/版本${{ steps.prepare.outputs.tag_version }}/g" README.md
+
+          echo "更新MD文档URL"
+          sed -i "s|releases/tag/${{ steps.prepare.outputs.github_version }}|releases/tag/${{ steps.prepare.outputs.tag_version }}|g" README.md
+          
+          echo "更新文档中java运行"
+          sed -i "s/BiliBili_Danmuji-${{ steps.prepare.outputs.github_version }}beta/BiliBili_Danmuji-${{ steps.prepare.outputs.tag_version }}beta/g" README.md
+          
+          git add README.md
+          git commit -m "${{ steps.prepare.outputs.tag_version }} update"
+
+      # 推送版本号到GitHub 
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ java version "1.8.0_121"
 项目目录下控制台执行：
 
 ```bash
-$ java -jar BiliBili_Danmuji-2.0beta.jar
+$ java -jar BiliBili_Danmuji-2.7.0.0beta.jar
 ```
 
 如果Window系统还可以：<br/>
@@ -289,7 +289,7 @@ $ java -jar BiliBili_Danmuji-2.0beta.jar
 
 - **自从2.4.5增加说明文件readme.txt和启动配置run.bat的端口参数 旧版本也可以自己加上去**<br/>
 - **--server.port=23333 修改即可修改端口启动**<br/>
-- **完整命令行：java -jar BiliBili_Danmuji-2.4.5beta.jar --server.port=23333**<br/>
+- **完整命令行：java -jar BiliBili_Danmuji-2.7.0.0beta.jar --server.port=23333**<br/>
 - **以上方法均兼容旧版本**
   <br/><br/>
   <br/>
@@ -298,8 +298,8 @@ $ java -jar BiliBili_Danmuji-2.0beta.jar
 
 - **自从2.4.7增加说明文件readme.txt和启动配置run.bat的内存参数 旧版本也可以自己加上去**<br/>
 - **-Xms64m -Xmx128m**<br/>
-- **完整命令行：java -jar -Xms64m -Xmx128m BiliBili_Danmuji-2.4.7beta.jar**<br/>
-- **加上修改端口的完整命令行：java -jar -Xms64m -Xmx128m BiliBili_Danmuji-2.4.7beta.jar --server.port=23333**<br/>
+- **完整命令行：java -jar -Xms64m -Xmx128m BiliBili_Danmuji-2.7.0.0beta.jar**<br/>
+- **加上修改端口的完整命令行：java -jar -Xms64m -Xmx128m BiliBili_Danmuji-2.7.0.0beta.jar --server.port=23333**<br/>
 - **以上方法均兼容旧版本**
   <br/><br/>
   <br/>


### PR DESCRIPTION
添加新发布脚本 release_update_readme
使用此脚本发布 会更新README.md文档
1.  `# 版本2.7.0.0` 改成 `# 版本${当前版本}`
2.  `/releases/tag/2.7.0.0` 改成 `/releases/tag/${当前版本}`
3. `BiliBili_Danmuji-2.7.0.0beta.jar` 改成 `BiliBili_Danmuji-${当前版本}beta.jar`

使用此脚本前 请先修改 下方代码 初始化git
```
          git config --global user.name 
          git config --global user.email 
```

添加删除脚本 delete_old_workflow
此脚本会每天执行一次，最多保存3条GitHub action记录

